### PR TITLE
Fix #7: make pin D0 selectable in top view

### DIFF
--- a/src/components/mcu.js
+++ b/src/components/mcu.js
@@ -74,7 +74,7 @@ export const MCU = observer(() => {
                             .map((p,num)=>
                                 <div style={{display:'flex',flexDirection:'row',justifyContent:'flex-end',alignItems:'center'}} key={num}>
                                     {p.name || pinNames[p.i]}
-                                    {p.i ?
+                                    {p.i != undefined ?
                                         <div 
                                             style={{
                                                 width:15,height:15,margin:10,


### PR DESCRIPTION
This commit updates the check so the falsey index `0` isn’t skipped.

This new right side check matches the existing conditional for the left side.