### PR TITLE
Make `voice` value match the selection UI

### DIFF
--- a/src/components/wavDetails.js
+++ b/src/components/wavDetails.js
@@ -92,7 +92,7 @@ export const WavDetails = observer(() => {
                 />
                 <Stack 
                     items={[
-                        store.currentVoice,
+                        store.currentVoice + 1,
                         range ? "range" : `${noteToName(store.wavBoardSelected)} ${noteToOctave(store.wavBoardSelected)}` || '',
                         range ? "range" : store.wavBoardSelected || '',
                         range ? "range" : name || 'empty',


### PR DESCRIPTION
Prior to this commit, the voice selection UI and voice # were off by one.
![CleanShot 2025-06-07 at 11 42 01@2x](https://github.com/user-attachments/assets/ad778d9c-8aa6-4bc5-822b-2409a422087b)